### PR TITLE
fix baro

### DIFF
--- a/Udral/barometer.cpp
+++ b/Udral/barometer.cpp
@@ -10,8 +10,7 @@
 namespace cyphal {
 
 BaroPressurePublisher::BaroPressurePublisher() :
-    CyphalPublisher(Cyphal::get_instance(), 65535) {
-};
+    CyphalPublisher(Cyphal::get_instance(), 65535) { }
 
 void BaroPressurePublisher::publish(const uavcan_si_sample_pressure_Scalar_1_0& msg) {
     static uint8_t buffer[uavcan_si_sample_pressure_Scalar_1_0_EXTENT_BYTES_];
@@ -23,8 +22,7 @@ void BaroPressurePublisher::publish(const uavcan_si_sample_pressure_Scalar_1_0& 
 }
 
 BaroTemperaturePublisher::BaroTemperaturePublisher() :
-    CyphalPublisher(Cyphal::get_instance(), 65535) {
-};
+    CyphalPublisher(Cyphal::get_instance(), 65535) { }
 
 void BaroTemperaturePublisher::publish(const uavcan_si_sample_temperature_Scalar_1_0& msg) {
     static uint8_t buffer[uavcan_si_sample_temperature_Scalar_1_0_EXTENT_BYTES_];


### PR DESCRIPTION
fix warning

```
10.54 /catkin_ws/src/cyphal_communicator/Libs/cyphal_application/Udral/barometer.cpp:14:2: error: extra ‘;’ [-Werror=pedantic]
10.54    14 | };
10.54       |  ^
10.54 /catkin_ws/src/cyphal_communicator/Libs/cyphal_application/Udral/barometer.cpp:27:2: error: extra ‘;’ [-Werror=pedantic]
10.54    27 | };
10.54       |  ^
10.54 cc1plus: all warnings being treated as errors
10.54 make[2]: *** [CMakeFiles/cyphal_communicator.dir/build.make:102: CMakeFiles/cyphal_communicator.dir/Libs/cyphal_application/Udral/barometer.cpp.o] Error 1
```